### PR TITLE
Fix bdist_rpm with epoch version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ class PyTest(TestCommand):
         errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
 
+
 def read(fname):
     """Utility function to read the README file.
 
@@ -57,12 +58,24 @@ class bdist_rpm(bdist_rpm_original):
         """Before calling the original run method, let's change the
         distribution name to create an RPM for python-isodatetime."""
         self.distribution.metadata.name = "python-isodatetime"
+        _, _, version = __version__.partition("!")
+        self.distribution.metadata.version = version
         super().run()
+
+
+version = __version__
+
+# From: # https://github.com/google/dotty/pull/20/files
+if (version[1] == "!" and (
+    "bdist_msi" in sys.argv or "bdist_rpm" in sys.argv)):
+    # bdist_msi and bdist_rpm do not support a setuptools epoch version so
+    # we remove it as a work around.
+    _, _, version = version.partition("!")
 
 
 setup(
     name="isodatetime",
-    version=__version__,
+    version=version,
     author="Met Office",
     author_email="metomi@metoffice.gov.uk",
     cmdclass={


### PR DESCRIPTION
Adds one space before `read` (for PEP8), and fixes the `bdist_rpm`. I was going to hit the approve button, but before executed the unit tests in my IDE, and also on the command line. Which gave me around 20 minutes to play around with the package and command while the timepoint tests ran.

Everything worked fine in the tests, but in the last test, to generate the RPM, it failed with

```
removing 'python-isodatetime-1!2.0b1' (and everything under it)
copying dist/python-isodatetime-1!2.0b1.tar.gz -> build/bdist.linux-x86_64/rpm/SOURCES
building RPMs
error: line 9: Illegal char '!' (0x21) in: Version: 1!2.0b1
error: query of specfile build/bdist.linux-x86_64/rpm/SPECS/python-isodatetime.spec failed, can't parse
error: Failed to execute: "rpm -q --qf '%{name}-%{version}-%{release}.src.rpm %{arch}/%{name}-%{version}-%{release}.%{arch}.rpm\\n' --specfile 'build/bdist.linux-x86_64/rpm/SPECS/python-isodatetime.spec'"
```

Found one google library that had similar issue, and copied [their approach](https://github.com/google/dotty/pull/20/files). It could be done within the `bdist_rpm` class, but I thought better to use their example as we can just add more to the `if` statement, in case other commands also fail with the new epoch version.

Nothing more from me after this one, promise!